### PR TITLE
Allow alternate extensions for c++ files

### DIFF
--- a/cmake_converter/project_variables.py
+++ b/cmake_converter/project_variables.py
@@ -223,10 +223,8 @@ class ProjectVariables(object):
         :type language: str
         """
 
-        available_language = {
-            'cpp': 'CXX',
-            'c': 'C'
-        }
+        available_language = {'c'  : 'C'}
+        available_language.update(dict.fromkeys(['cc', 'cp', 'cxx', 'cpp', 'CPP', 'c++', 'C'], 'CXX'))
 
         self.cmake.write('\n')
         self.cmake.write(

--- a/cmake_converter/project_variables.py
+++ b/cmake_converter/project_variables.py
@@ -223,8 +223,10 @@ class ProjectVariables(object):
         :type language: str
         """
 
-        available_language = {'c'  : 'C'}
-        available_language.update(dict.fromkeys(['cc', 'cp', 'cxx', 'cpp', 'CPP', 'c++', 'C'], 'CXX'))
+        CPP_EXTENSIONS = ['cc', 'cp', 'cxx', 'cpp', 'CPP', 'c++', 'C']
+
+        available_language = {'c':'C'}
+        available_language.update(dict.fromkeys(CPP_EXTENSIONS, 'CXX'))
 
         self.cmake.write('\n')
         self.cmake.write(

--- a/cmake_converter/project_variables.py
+++ b/cmake_converter/project_variables.py
@@ -225,7 +225,7 @@ class ProjectVariables(object):
 
         CPP_EXTENSIONS = ['cc', 'cp', 'cxx', 'cpp', 'CPP', 'c++', 'C']
 
-        available_language = {'c':'C'}
+        available_language = {'c': 'C'}
         available_language.update(dict.fromkeys(CPP_EXTENSIONS, 'CXX'))
 
         self.cmake.write('\n')


### PR DESCRIPTION
GNU allows more extensions than just .cpp, listed here:
https://gcc.gnu.org/onlinedocs/gcc-4.4.1/gcc/Overall-Options.html#index-file-name-suffix-71