### PR TITLE
Added "generating files" signature for add_custom_command_if

### DIFF
--- a/cmake_converter/utils.cmake
+++ b/cmake_converter/utils.cmake
@@ -1,32 +1,13 @@
 # utils file for projects came from visual studio solution with cmake-converter.
 
 ################################################################################
-# Parse add_custom_command_if args.
-# Input:
-#    Options:        PRE_BUILD, PRE_LINK, POST_BUILD
-#    One value args: TARGET
-#    List:           List of commands(COMMAND condition1 commannd1 args1 COMMAND condition2 commannd2 args2 ...)
-# Output:
-#    PRE_BUILD  - TRUE/FALSE
-#    PRE_LINK   - TRUE/FALSE
-#    POST_BUILD - TRUE/FALSE
-#    TARGET     - Target name
-#    COMMANDS   - Prepared commands(every token is wrapped in CONDITION)
-#    NAME       - Unique name for custom target
-#    STEP       - PRE_BUILD/PRE_LINK/POST_BUILD
+# Wrap each token of the command with condition
 ################################################################################
 cmake_policy(PUSH)
 cmake_policy(SET CMP0054 NEW)
-function(add_custom_command_if_parse_arguments)
-    cmake_parse_arguments("ARG" "PRE_BUILD;PRE_LINK;POST_BUILD" "TARGET" "" ${ARGN})
-
+macro(PREPARE_COMMANDS)
     unset(COMMANDS)
-    if(WIN32)
-        set(DUMMY "cd.")
-    elseif(UNIX)
-        set(DUMMY "true")
-    endif()
-    foreach(TOKEN ${ARG_UNPARSED_ARGUMENTS})
+    foreach(TOKEN ${ARG_COMMANDS})
         if("${TOKEN}" STREQUAL "COMMAND")
             set(TOKEN_ROLE "KEYWORD")
         elseif("${TOKEN_ROLE}" STREQUAL "KEYWORD")
@@ -47,7 +28,64 @@ function(add_custom_command_if_parse_arguments)
             list(APPEND COMMANDS "$<${CONDITION}:${TOKEN}>")
         endif()
     endforeach()
+endmacro()
+cmake_policy(POP)
 
+################################################################################
+# Transform all the tokens to absolute paths
+################################################################################
+macro(PREPARE_OUTPUT)
+    unset(OUTPUT)
+    foreach(TOKEN ${ARG_OUTPUT})
+        if(IS_ABSOLUTE ${TOKEN})
+            list(APPEND OUTPUT "${TOKEN}")
+        else()
+            list(APPEND OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/${TOKEN}")
+        endif()
+    endforeach()
+endmacro()
+
+################################################################################
+# Parse add_custom_command_if args.
+# Input:
+#    Options:
+#       PRE_BUILD  - Pre build event
+#       PRE_LINK   - Pre link event
+#       POST_BUILD - Post build event
+#
+#    One value args:
+#       TARGET - Target
+#       OUTPUT - Output files
+#
+#    Lists:
+#       DEPENDS  - Files on which the command depends
+#       COMMANDS - List of commands(COMMAND condition1 commannd1 args1 COMMAND condition2 commannd2 args2 ...)
+# Output:
+#    OUTPUT     - Output files
+#    DEPENDS    - Files on which the command depends
+#    COMMENT    - Comment
+#    PRE_BUILD  - TRUE/FALSE
+#    PRE_LINK   - TRUE/FALSE
+#    POST_BUILD - TRUE/FALSE
+#    TARGET     - Target name
+#    COMMANDS   - Prepared commands(every token is wrapped in CONDITION)
+#    NAME       - Unique name for custom target
+#    STEP       - PRE_BUILD/PRE_LINK/POST_BUILD
+################################################################################
+function(add_custom_command_if_parse_arguments)
+    cmake_parse_arguments("ARG" "PRE_BUILD;PRE_LINK;POST_BUILD" "TARGET;COMMENT" "DEPENDS;OUTPUT;COMMANDS" ${ARGN})
+
+    if(WIN32)
+        set(DUMMY "cd.")
+    elseif(UNIX)
+        set(DUMMY "true")
+    endif()
+
+    PREPARE_COMMANDS()
+    PREPARE_OUTPUT()
+
+    set(DEPENDS "${ARG_DEPENDS}")
+    set(COMMENT "${ARG_COMMENT}")
     set(PRE_BUILD "${ARG_PRE_BUILD}")
     set(PRE_LINK "${ARG_PRE_LINK}")
     set(POST_BUILD "${ARG_POST_BUILD}")
@@ -61,6 +99,9 @@ function(add_custom_command_if_parse_arguments)
     endif()
     set(NAME "${TARGET}_${STEP}")
 
+    set(OUTPUT "${OUTPUT}" PARENT_SCOPE)
+    set(DEPENDS "${DEPENDS}" PARENT_SCOPE)
+    set(COMMENT "${COMMENT}" PARENT_SCOPE)
     set(PRE_BUILD "${PRE_BUILD}" PARENT_SCOPE)
     set(PRE_LINK "${PRE_LINK}" PARENT_SCOPE)
     set(POST_BUILD "${POST_BUILD}" PARENT_SCOPE)
@@ -69,30 +110,58 @@ function(add_custom_command_if_parse_arguments)
     set(STEP "${STEP}" PARENT_SCOPE)
     set(NAME "${NAME}" PARENT_SCOPE)
 endfunction()
-cmake_policy(POP)
 
 ################################################################################
-# Add custom command if condition is TRUE
-# add_custom_command_if(
-#     TARGET target
-#     PRE_BUILD | PRE_LINK | POST_BUILD
-#     COMMAND condition command1 [args1...]
-#     [COMMAND condition command2 [args2...]]
+# There are two main signatures for add_custom_command_if.
+#
+# Generating Files
+# The first signature is for adding a custom command to produce an output:
+#     add_custom_command_if(
+#         OUTPUT output1 [output2 ...]
+#         COMMANDS
+#         COMMAND condition command1 [args1...]
+#         [COMMAND condition command2 [args2...]]
+#         [DEPENDS [depends...]]
+#         [COMMENT comment]
+#
+# Build Events
+#     add_custom_command_if(
+#         TARGET target
+#         PRE_BUILD | PRE_LINK | POST_BUILD
+#         COMMAND condition command1 [args1...]
+#         [COMMAND condition command2 [args2...]]
+#         [COMMENT comment]
 ################################################################################
 function(add_custom_command_if)
     add_custom_command_if_parse_arguments(${ARGN})
 
-    if(PRE_BUILD AND NOT ${CMAKE_GENERATOR} MATCHES "Visual Studio")
-        add_custom_target(
-            ${NAME}
-            ${COMMANDS}
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-        add_dependencies(${TARGET} ${NAME})
+    if(OUTPUT AND TARGET)
+        message(FATAL_ERROR  "Wrong syntax. A TARGET and OUTPUT can not both be specified.")
+    endif()
+
+    if(OUTPUT)
+        add_custom_command(OUTPUT ${OUTPUT}
+                           ${COMMANDS}
+                           DEPENDS ${DEPENDS}
+                           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                           COMMENT ${COMMENT})
+    elseif(TARGET)
+        if(PRE_BUILD AND NOT ${CMAKE_GENERATOR} MATCHES "Visual Studio")
+            add_custom_target(
+                ${NAME}
+                ${COMMANDS}
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                COMMENT ${COMMENT})
+            add_dependencies(${TARGET} ${NAME})
+        elseif()
+            add_custom_command(
+                TARGET ${TARGET}
+                ${STEP}
+                ${COMMANDS}
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                COMMENT ${COMMENT})
+        endif()
     else()
-        add_custom_command(
-            TARGET ${TARGET}
-            ${STEP}
-            ${COMMANDS}
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+        message(FATAL_ERROR "Wrong syntax. A TARGET or OUTPUT must be specified.")
     endif()
 endfunction()


### PR DESCRIPTION
Call syntax changed a little bit. Before:

```
    add_custom_command_if(
        TARGET ${PROJECT_NAME}
        PRE_BUILD
        COMMAND   $<CONFIG:Debug> util arg1 arg2 arg3
        COMMAND   $<CONFIG:Release> util arg1 arg2 arg3
    )
```

After:

```
    add_custom_command_if(
        TARGET ${PROJECT_NAME}
        PRE_BUILD
        COMMANDS
        COMMAND   $<CONFIG:Debug> util arg1 arg2 arg3
        COMMAND   $<CONFIG:Release> util arg1 arg2 arg3
    )
```