### PR TITLE
Added script for setting default C++ properties

### DIFF
--- a/cmake_converter/DefaultCXX.cmake
+++ b/cmake_converter/DefaultCXX.cmake
@@ -1,0 +1,77 @@
+set(PROPERTY_READER_GUARD_IGNORE "${CMAKE_CURRENT_LIST_FILE}")
+
+################################################################################
+# Command for variable_watch. This command issues error message, if a variable 
+# is chaged in the file that is not listed in PROPERTY_READER_GUARD_IGNORE 
+# variable.
+#     variable_watch(<variable> property_reader_guard)
+################################################################################
+function(property_reader_guard VARIABLE ACCESS VALUE CURRENT_LIST_FILE STACK)
+    if("${CURRENT_LIST_FILE}" IN_LIST PROPERTY_READER_GUARD_IGNORE)
+        return()
+    endif()
+
+    if("${ACCESS}" STREQUAL "MODIFIED_ACCESS")
+        message(FATAL_ERROR
+            " Variable ${VARIABLE} is not supposed to be changed.\n"
+            " It is used only for reading target property ${VARIABLE}.\n"
+            " Use\n"
+            "     set_target_properties(\"<target>\" PROPERTIES \"${VARIABLE}\" \"<value>\")\n"
+            " or\n"
+            "     set_target_properties(\"<target>\" PROPERTIES \"${VARIABLE}_<CONFIG>\" \"<value>\")\n"
+            " instead.\n")
+    endif()
+endfunction()
+
+################################################################################
+# Create variable <name> with generator expression that expands to value of
+# target property <name>_<CONFIG>. If property is empty or not set then property
+# <name> is used instead. Variable <name> has watcher property_reader_guard that
+# doesn't allow to edit it.
+#     create_property_reader(<name>)
+# Input:
+#     name - Name of watched property and output variable
+################################################################################
+function(create_property_reader NAME)
+    set(CONFIG_VALUE "$<TARGET_GENEX_EVAL:${PROPS_TARGET},$<TARGET_PROPERTY:${PROPS_TARGET},${NAME}_$<UPPER_CASE:$<CONFIG>>>>")
+    set(IS_CONFIG_VALUE_EMPTY "$<STREQUAL:${CONFIG_VALUE},>")
+    set(GENERAL_VALUE "$<TARGET_GENEX_EVAL:${PROPS_TARGET},$<TARGET_PROPERTY:${PROPS_TARGET},${NAME}>>")
+    set("${NAME}" "$<IF:${IS_CONFIG_VALUE_EMPTY},${GENERAL_VALUE},${CONFIG_VALUE}>" PARENT_SCOPE)
+    variable_watch("${NAME}" property_reader_guard)
+endfunction()
+
+################################################################################
+# Set property $<name>_${PROPS_CONFIG_U} of ${PROPS_TARGET} to <value>
+#     set_config_specific_property(<name> <value>)
+# Input:
+#     name  - Prefix of property name
+#     value - New value
+################################################################################
+function(set_config_specific_property NAME VALUE)
+    set_target_properties("${PROPS_TARGET}" PROPERTIES "${NAME}_${PROPS_CONFIG_U}" "${VALUE}")
+endfunction()
+
+################################################################################
+
+create_property_reader("TARGET_NAME")
+create_property_reader("OUTPUT_DIRECTORY")
+
+create_property_reader("DEFAULT_CXX_DEBUG_RUNTIME_LIBRARY")
+create_property_reader("DEFAULT_CXX_RUNTIME_LIBRARY")
+create_property_reader("DEFAULT_CXX_EXCEPTION_HANDLING")
+
+
+set_config_specific_property("TARGET_NAME" "${PROPS_TARGET}")
+set_config_specific_property("OUTPUT_NAME" "${TARGET_NAME}")
+set_config_specific_property("ARCHIVE_OUTPUT_NAME" "${TARGET_NAME}")
+set_config_specific_property("LIBRARY_OUTPUT_NAME" "${TARGET_NAME}")
+set_config_specific_property("RUNTIME_OUTPUT_NAME" "${TARGET_NAME}")
+
+set_config_specific_property("OUTPUT_DIRECTORY" "${CMAKE_SOURCE_DIR}/${CMAKE_VS_PLATFORM_NAME}/${PROPS_CONFIG}")
+set_config_specific_property("ARCHIVE_OUTPUT_DIRECTORY" "${OUTPUT_DIRECTORY}")
+set_config_specific_property("LIBRARY_OUTPUT_DIRECTORY" "${OUTPUT_DIRECTORY}")
+set_config_specific_property("RUNTIME_OUTPUT_DIRECTORY" "${OUTPUT_DIRECTORY}")
+
+set_config_specific_property("DEFAULT_CXX_DEBUG_RUNTIME_LIBRARY" "/MDd")
+set_config_specific_property("DEFAULT_CXX_RUNTIME_LIBRARY" "/MD")
+set_config_specific_property("DEFAULT_CXX_EXCEPTION_HANDLING" "/EHs")

--- a/cmake_converter/utils.cmake
+++ b/cmake_converter/utils.cmake
@@ -296,3 +296,8 @@ function(source_file_compile_options SOURCE_FILE)
 
     set_source_files_properties("${SOURCE_FILE}" PROPERTIES COMPILE_OPTIONS "${COMPILE_OPTIONS}")
 endfunction()
+
+################################################################################
+# Default properties of C++ projects
+################################################################################
+set(DEFAULT_CXX_PROPS "${CMAKE_CURRENT_LIST_DIR}/DefaultCXX.cmake")


### PR DESCRIPTION
Usage:

```
    use_props(Target "${CMAKE_CONFIGURATION_TYPES}" "${DEFAULT_CXX_PROPS}")
    #...
    set_target_properties(
        ${PROJECT_NAME} 
        PROPERTIES
        TARGET_NAME_RELEASE "Foo"
        OUTPUT_DIRECTORY_DEBUG "/custom/out/dir"
    )
    #...
    target_compile_options(
        ${PROJECT_NAME} 
        PRIVATE 
        ${DEFAULT_CXX_RUNTIME_LIBRARY} 
        ${DEFAULT_CXX_DEBUG_RUNTIME_LIBRARY} 
        ${DEFAULT_CXX_EXCEPTION_HANDLING}
    )
```

Available variables:
 - `DEFAULT_CXX_DEBUG_RUNTIME_LIBRARY` refers target property `DEFAULT_CXX_RUNTIME_LIBRARY_<CONFIG>` with default value `/MDd`.
 - `DEFAULT_CXX_RUNTIME_LIBRARY` refers target property `DEFAULT_CXX_RUNTIME_LIBRARY_<CONFIG>` with default value `/MD`.
 - `DEFAULT_CXX_EXCEPTION_HANDLING` refers target property `DEFAULT_CXX_EXCEPTION_HANDLING_<CONFIG>` with default value `/EHs`.
 - `TARGET_NAME` refers target property `TARGET_NAME_<CONFIG>` with name of current target as default value.
- `OUTPUT_DIRECTORY` refers target property `OUTPUT_DIRECTORY_<CONFIG>` with default value `"${CMAKE_SOURCE_DIR}/${CMAKE_VS_PLATFORM_NAME}/<CONFIG>"`

